### PR TITLE
Allow project settings to be configurable

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -685,3 +685,10 @@ div.gutter {
   width: 0.125em;
   background: #ccc;
 }
+
+.project-settings-dialog {
+  td.MuiTableCell-root.MuiTableCell-body {
+    // Reduce the default 16px padding
+    padding: 8px;
+  }
+}

--- a/src/bindings/Project.ts
+++ b/src/bindings/Project.ts
@@ -10,6 +10,8 @@ import { BundledGradleBuild } from "../bundled_files/build.gradle"
 import { generateReadme } from "../bundled_files/README.md"
 import { BundledLaunchJson, BundledSettingsJson } from "../bundled_files/vscode"
 import { BundledWpilibCommandsV2 } from "../bundled_files/vendordeps"
+import { className } from "../codegen/java/util"
+import { generateSubsystem } from "../codegen/java/SubsystemGenerator"
 
 export type GeneratedFile = {
   name: string
@@ -128,6 +130,23 @@ export const makeNewProject = (): Project => {
 
 export function updateFile(project: Project, path: string, contents: string): void {
   project.generatedFiles.find(f => f.name === path).contents = contents
+}
+
+/**
+ * Regenerates all dynamic project files.
+ * 
+ * @param project the project to regenerate
+ */
+export function regenerateFiles(project: Project): void {
+  // Regenerate subsystems
+  project.subsystems.forEach(subsytem => {
+    updateFile(project, `src/main/java/frc/robot/subsystems/${ className(subsytem.name) }.java`, generateSubsystem(subsytem, project))
+  })
+  
+  updateFile(project, "src/main/java/frc/robot/Robot.java", generateRobotClass(project))
+
+  updateFile(project, `README.md`, generateReadme(project))
+  updateFile(project, ".wpilib/wpilib_preferences.json", generateBundledPreferences(project))
 }
 
 export function findCommand(project: Project, commandOrId: AtomicCommand | IR.Group | string): AtomicCommand | IR.Group | null {

--- a/src/bindings/Project.ts
+++ b/src/bindings/Project.ts
@@ -21,7 +21,6 @@ export type GeneratedFile = {
 }
 
 export type Project = {
-  name: string
   controllers: Controller[]
   subsystems: Subsystem[]
   commands: IR.Group[]
@@ -30,6 +29,7 @@ export type Project = {
 };
 
 export type Settings = {
+  name: string
   /**
    * The number of the FRC team the project targets. This is used in the wpilib_preferences.json file
    * and in the build.gradle file. Defaults to 0; users will need to change it to their team number
@@ -105,7 +105,6 @@ const makeDefaultGeneratedFiles = (): GeneratedFile[] => {
 
 export const makeNewProject = (): Project => {
   const project: Project = {
-    name: "",
     controllers: [
       { name: "New Controller", uuid: uuidV4(), type: "ps5", className: "CommandPS5Controller", fqn: "", port: 1 , buttons: [] },
     ],
@@ -113,7 +112,8 @@ export const makeNewProject = (): Project => {
     commands: [],
     generatedFiles: makeDefaultGeneratedFiles(),
     settings: {
-      teamNumber: 0,
+      name: "",
+      teamNumber: null,
       epilogueSupport: true,
       custom: {},
     },

--- a/src/bindings/Project.ts
+++ b/src/bindings/Project.ts
@@ -105,7 +105,7 @@ const makeDefaultGeneratedFiles = (): GeneratedFile[] => {
 
 export const makeNewProject = (): Project => {
   const project: Project = {
-    name: "New Project",
+    name: "",
     controllers: [
       { name: "New Controller", uuid: uuidV4(), type: "ps5", className: "CommandPS5Controller", fqn: "", port: 1 , buttons: [] },
     ],

--- a/src/bindings/Project.ts
+++ b/src/bindings/Project.ts
@@ -28,24 +28,48 @@ export type Project = {
   settings: Settings
 };
 
-export type Settings = {
+export type SettingsKey = string
+export type SettingsType = string | number | boolean | null
+export type SettingsTypeName = "string" | "number" | "boolean"
+
+export type Settings = Record<SettingsKey, SettingsType>
+
+export type SettingsCategory = {
+  key: string
   name: string
+  settings: SettingConfig[]
+}
+
+export type SettingConfig = {
   /**
-   * The number of the FRC team the project targets. This is used in the wpilib_preferences.json file
-   * and in the build.gradle file. Defaults to 0; users will need to change it to their team number
-   * before being able to export.
+   * A unique key to identify this setting. For example, a UUID or a unique identifier like "wpilib.epilogue.enabled".
    */
-  teamNumber: number
+  key: SettingsKey
 
   /**
-   * Whether or not to include Epilogue logging support in generated files. Defaults to `true`.
+   * The name of the setting to display to users.
    */
-  epilogueSupport: boolean
+  name: string
 
   /**
-   * Any custom project settings provided by third party extensions.
+   * A description of this setting and what it does or how it's used.
    */
-  custom: Record<string, unknown>
+  description: string
+
+  /**
+   * Whether or not the setting is required.
+   */
+  required: boolean
+
+  /**
+   * The data type of the setting object. This will be used to determine the UI element that edits this setting.
+   */
+  type: SettingsTypeName
+
+  /**
+   * The default value of the setting.
+   */
+  defaultValue: SettingsType
 }
 
 const makeDefaultGeneratedFiles = (): GeneratedFile[] => {
@@ -112,10 +136,10 @@ export const makeNewProject = (): Project => {
     commands: [],
     generatedFiles: makeDefaultGeneratedFiles(),
     settings: {
-      name: "",
-      teamNumber: null,
-      epilogueSupport: true,
-      custom: {},
+      "robotbuilder.general.project_name": "",
+      "robotbuilder.general.team_number": null,
+      // "robotbuilder.general.cache_sensor_values": false,
+      "wpilib.epilogue.enabled": true,
     },
   } 
   

--- a/src/bundled_files/README.md.ts
+++ b/src/bundled_files/README.md.ts
@@ -3,7 +3,7 @@ import { unindent } from "../codegen/java/util"
 
 export const generateReadme = (project: Project): string => {
   return unindent(`
-    # ${ project.name }
+    # ${ project.settings.name }
 
     This is your robot program!
   `).trim()

--- a/src/bundled_files/README.md.ts
+++ b/src/bundled_files/README.md.ts
@@ -3,7 +3,7 @@ import { unindent } from "../codegen/java/util"
 
 export const generateReadme = (project: Project): string => {
   return unindent(`
-    # ${ project.settings.name }
+    # ${ project.settings["robotbuilder.general.project_name"] }
 
     This is your robot program!
   `).trim()

--- a/src/bundled_files/wpilib_preferences.json.ts
+++ b/src/bundled_files/wpilib_preferences.json.ts
@@ -7,7 +7,7 @@ export const generateBundledPreferences = (project: Project): string => {
       "enableCppIntellisense": false,
       "currentLanguage": "java",
       "projectYear": "2025",
-      "teamNumber": ${ project.settings.teamNumber }
+      "teamNumber": ${ project.settings["robotbuilder.general.team_number"] }
     }
   `).trim()
 }

--- a/src/bundled_files/wpilib_preferences.json.ts
+++ b/src/bundled_files/wpilib_preferences.json.ts
@@ -1,10 +1,13 @@
+import { Project } from "../bindings/Project"
 import { unindent } from "../codegen/java/util"
 
-export const BundledPreferences = unindent(`
-  {
-    "enableCppIntellisense": false,
-    "currentLanguage": "java",
-    "projectYear": "2025",
-    "teamNumber": 9999
-  }
-`).trim()
+export const generateBundledPreferences = (project: Project): string => {
+  return unindent(`
+    {
+      "enableCppIntellisense": false,
+      "currentLanguage": "java",
+      "projectYear": "2025",
+      "teamNumber": ${ project.settings.teamNumber }
+    }
+  `).trim()
+}

--- a/src/codegen/java/RobotGenerator.ts
+++ b/src/codegen/java/RobotGenerator.ts
@@ -10,16 +10,16 @@ export function generateRobotClass(project: Project): string {
     `
     package frc.robot;
 
-    ${ project.settings.epilogueSupport ? "import edu.wpi.first.epilogue.Epilogue;" : "" }
-    ${ project.settings.epilogueSupport ? "import edu.wpi.first.epilogue.Logged;" : "" }
-    ${ project.settings.epilogueSupport ? "import edu.wpi.first.epilogue.NotLogged;" : "" }
+    ${ project.settings["wpilib.epilogue.enabled"] ? "import edu.wpi.first.epilogue.Epilogue;" : "" }
+    ${ project.settings["wpilib.epilogue.enabled"] ? "import edu.wpi.first.epilogue.Logged;" : "" }
+    ${ project.settings["wpilib.epilogue.enabled"] ? "import edu.wpi.first.epilogue.NotLogged;" : "" }
     import edu.wpi.first.wpilibj.RuntimeType;
     import edu.wpi.first.wpilibj.TimedRobot;
     import edu.wpi.first.wpilibj2.command.Command;
     import edu.wpi.first.wpilibj2.command.CommandScheduler;
     import frc.robot.subsystems.*;
 
-    ${ project.settings.epilogueSupport ? "@Logged" : "" }
+    ${ project.settings["wpilib.epilogue.enabled"] ? "@Logged" : "" }
     public class Robot extends TimedRobot {
 ${
   project.subsystems.map(s => generateSubsystemDeclaration(project, s)).join("\n")
@@ -27,7 +27,7 @@ ${
 
 ${
   project.controllers.map(c => `
-    ${ project.settings.epilogueSupport ? `@NotLogged // Controllers are not loggable` : "" }
+    ${ project.settings["wpilib.epilogue.enabled"] ? `@NotLogged // Controllers are not loggable` : "" }
     private final ${ c.className } ${ methodName(c.name) } = new ${ c.className }(${ c.port });
     `)
 }
@@ -36,7 +36,7 @@ ${
         configureButtonBindings();
         configureAutomaticBindings();
 
-        ${ project.settings.epilogueSupport ? `
+        ${ project.settings["wpilib.epilogue.enabled"] ? `
           Epilogue.configure(config -> {
             // TODO: Add a UI for customizing epilogue
 
@@ -59,7 +59,7 @@ ${
         CommandScheduler.getInstance().run();
 
         ${
-  project.settings.epilogueSupport ?
+  project.settings["wpilib.epilogue.enabled"] ?
     `
             // Update our data logs
             Epilogue.update(this);
@@ -108,7 +108,7 @@ ${
 function generateSubsystemDeclaration(project: Project, subsystem: Subsystem): string {
   return indent(
     `
-      ${ project.settings.epilogueSupport ? `@Logged(name = "${ subsystem.name }")` : "" }
+      ${ project.settings["wpilib.epilogue.enabled"] ? `@Logged(name = "${ subsystem.name }")` : "" }
       private final ${ className(subsystem.name) } ${ methodName(subsystem.name) } = new ${ className(subsystem.name) }();
     `.trim(),
     2,

--- a/src/codegen/java/StateGenerator.ts
+++ b/src/codegen/java/StateGenerator.ts
@@ -7,7 +7,7 @@ export function generateState(project: Project, state: SubsystemState, subsystem
   console.log("[STATE-GENERATOR] Generating code for state", state)
   return unindent(
     `
-    ${ project.settings.epilogueSupport ?  `@Logged(name = "${ state.name }?")` : "" }
+    ${ project.settings["wpilib.epilogue.enabled"] ?  `@Logged(name = "${ state.name }?")` : "" }
     public boolean ${ methodName(state.name) }(${ generateStepParams([state.step].filter(s => !!s), subsystem) }) {
 ${ generateStepInvocations([state.step].filter(s => !!s), subsystem).map(i => indent(`return ${ i }`, 6)).join("\n") }
     }

--- a/src/codegen/java/StateGenerator.ts
+++ b/src/codegen/java/StateGenerator.ts
@@ -1,12 +1,13 @@
 import { Subsystem, SubsystemState } from "../../bindings/Command"
 import { indent, methodName, unindent } from "./util"
 import { generateStepInvocations, generateStepParams } from "./ActionGenerator"
+import { Project } from "../../bindings/Project"
 
-export function generateState(state: SubsystemState, subsystem: Subsystem): string {
+export function generateState(project: Project, state: SubsystemState, subsystem: Subsystem): string {
   console.log("[STATE-GENERATOR] Generating code for state", state)
   return unindent(
     `
-    @Logged(name = "${ state.name }?")
+    ${ project.settings.epilogueSupport ?  `@Logged(name = "${ state.name }?")` : "" }
     public boolean ${ methodName(state.name) }(${ generateStepParams([state.step].filter(s => !!s), subsystem) }) {
 ${ generateStepInvocations([state.step].filter(s => !!s), subsystem).map(i => indent(`return ${ i }`, 6)).join("\n") }
     }

--- a/src/codegen/java/SubsystemGenerator.ts
+++ b/src/codegen/java/SubsystemGenerator.ts
@@ -114,7 +114,9 @@ export function generateSubsystem(subsystem: Subsystem, project: Project) {
     import static edu.wpi.first.units.Units.*;
 
 ${ [...new Set(subsystem.components.map(c => c.definition.fqn))].sort().map(fqn => indent(`import ${ fqn };`, 4)).join("\n") }
-    import edu.wpi.first.epilogue.Logged;
+
+    ${ project.settings.epilogueSupport ? "import edu.wpi.first.epilogue.Logged;" : "" }
+    ${ project.settings.epilogueSupport ? "import edu.wpi.first.epilogue.NotLogged;" : "" }
     import edu.wpi.first.units.*;
     import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
     import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
@@ -125,10 +127,10 @@ ${ [...new Set(subsystem.components.map(c => c.definition.fqn))].sort().map(fqn 
     /**
      * The ${ subsystem.name } subsystem.
      */
-    @Logged
+    ${ project.settings.epilogueSupport ? "@Logged" : "" }
     public class ${ clazz } extends SubsystemBase {
 
-${ subsystem.components.map(c => indent(`${ fieldDeclaration(c.definition.className, c.name) };`, 6)).join("\n") }
+${ subsystem.components.map(c => indent(`${ fieldDeclaration(project, c.definition.className, c.name) };`, 6)).join("\n") }
 
 ${
   (() => {
@@ -150,7 +152,7 @@ ${
 ${ subsystem.states.map(state => {
     return indent(unindent(
       `
-      @NotLogged
+      ${ project.settings.epilogueSupport ? "@NotLogged" : "" }
       public final Trigger ${ methodName(state.name) } = new Trigger(this::${ methodName(state.name) });
     `,
     ).trim(), 6)
@@ -183,7 +185,7 @@ ${
       // STATES
 
 ${
-  subsystem.states.map(state => unindent(indent(generateState(state, subsystem), 4)).trim())
+  subsystem.states.map(state => unindent(indent(generateState(project, state, subsystem), 4)).trim())
     .map(f => indent(f, 6)).join("\n\n")
 }
 

--- a/src/codegen/java/SubsystemGenerator.ts
+++ b/src/codegen/java/SubsystemGenerator.ts
@@ -115,8 +115,8 @@ export function generateSubsystem(subsystem: Subsystem, project: Project) {
 
 ${ [...new Set(subsystem.components.map(c => c.definition.fqn))].sort().map(fqn => indent(`import ${ fqn };`, 4)).join("\n") }
 
-    ${ project.settings.epilogueSupport ? "import edu.wpi.first.epilogue.Logged;" : "" }
-    ${ project.settings.epilogueSupport ? "import edu.wpi.first.epilogue.NotLogged;" : "" }
+    ${ project.settings["wpilib.epilogue.enabled"] ? "import edu.wpi.first.epilogue.Logged;" : "" }
+    ${ project.settings["wpilib.epilogue.enabled"] ? "import edu.wpi.first.epilogue.NotLogged;" : "" }
     import edu.wpi.first.units.*;
     import edu.wpi.first.wpilibj.shuffleboard.Shuffleboard;
     import edu.wpi.first.wpilibj.shuffleboard.ShuffleboardTab;
@@ -127,7 +127,7 @@ ${ [...new Set(subsystem.components.map(c => c.definition.fqn))].sort().map(fqn 
     /**
      * The ${ subsystem.name } subsystem.
      */
-    ${ project.settings.epilogueSupport ? "@Logged" : "" }
+    ${ project.settings["wpilib.epilogue.enabled"] ? "@Logged" : "" }
     public class ${ clazz } extends SubsystemBase {
 
 ${ subsystem.components.map(c => indent(`${ fieldDeclaration(project, c.definition.className, c.name) };`, 6)).join("\n") }
@@ -152,7 +152,7 @@ ${
 ${ subsystem.states.map(state => {
     return indent(unindent(
       `
-      ${ project.settings.epilogueSupport ? "@NotLogged" : "" }
+      ${ project.settings["wpilib.epilogue.enabled"] ? "@NotLogged" : "" }
       public final Trigger ${ methodName(state.name) } = new Trigger(this::${ methodName(state.name) });
     `,
     ).trim(), 6)

--- a/src/codegen/java/util.ts
+++ b/src/codegen/java/util.ts
@@ -95,7 +95,7 @@ export function objectName(name: string): string {
 
 export function fieldDeclaration(project: Project, type: string, name: string): string {
   return unindent(`
-    ${ project.settings.epilogueSupport ? `@Logged(name = "${ name }")` : "" }
+    ${ project.settings["wpilib.epilogue.enabled"] ? `@Logged(name = "${ name }")` : "" }
     private final ${ type } ${ objectName(name) }
   `).trim()
 }

--- a/src/codegen/java/util.ts
+++ b/src/codegen/java/util.ts
@@ -1,6 +1,7 @@
 import parsers from "prettier-plugin-java"
 import prettier from "prettier"
 import { Subsystem } from "../../bindings/Command"
+import { Project } from "../../bindings/Project"
 
 export const MAIN_CLASS_PATH = "src/main/java/frc/robot/Main.java"
 export const ROBOT_CLASS_PATH = "src/main/java/frc/robot/Robot.java"
@@ -92,9 +93,9 @@ export function objectName(name: string): string {
   }
 }
 
-export function fieldDeclaration(type: string, name: string): string {
+export function fieldDeclaration(project: Project, type: string, name: string): string {
   return unindent(`
-    @Logged(name = "${ name }")
+    ${ project.settings.epilogueSupport ? `@Logged(name = "${ name }")` : "" }
     private final ${ type } ${ objectName(name) }
   `).trim()
 }

--- a/src/settings/Settings.ts
+++ b/src/settings/Settings.ts
@@ -1,0 +1,56 @@
+import { SettingsCategory } from "../bindings/Project"
+
+export const ALL_SETTINGS = {}
+
+export function registerCategory(setting: SettingsCategory) {
+  ALL_SETTINGS[setting.key] = setting
+}
+
+// Seed default values
+
+registerCategory({
+  key: "robotbuilder.general",
+  name: "General",
+  settings: [
+    {
+      key: "robotbuilder.general.project_name",
+      name: "Project Name",
+      description: "The name of your robot project",
+      required: true,
+      type: "string",
+      defaultValue: null,
+    },
+    {
+      key: "robotbuilder.general.team_number",
+      name: "Team Number",
+      description: "Your FRC team number. You ought to know this!",
+      required: true,
+      type: "number",
+      defaultValue: null,
+    },
+    // TODO: Implement sensor caching. It's out of scope for the initial project settings work.
+    // {
+    //   key: "robotbuilder.general.cache_sensor_values",
+    //   name: "Cache Sensor Values",
+    //   description: "Changes code generation to read sensor values once per loop, instead of on demand. This setting may improve performance",
+    //   required: false,
+    //   type: "boolean",
+    //   defaultValue: false
+    // }
+  ],
+})
+
+registerCategory({
+  key: "wpilib.epilogue",
+  name: "Epilogue",
+  settings: [
+    {
+      key: "wpilib.epilogue.enabled",
+      name: "Enable Epilogue Support",
+      description: "Enables support for automatic data logging in your project via the Epilogue library",
+      required: false,
+      type: "boolean",
+      defaultValue: true,
+    },
+  ],
+})

--- a/src/ui/ProjectView.tsx
+++ b/src/ui/ProjectView.tsx
@@ -134,7 +134,7 @@ export function ProjectView({ initialProject }: ProjectProps) {
   const [project, setProject] = React.useState(initialProject)
   const [selectedTab, setSelectedTab] = React.useState(defaultTab)
   const [showSettings, setShowSettings] = React.useState(true)
-  const [projectSnapshot, setProjectSnapshot] = React.useState({ ...initialProject })
+  const [projectSnapshot, setProjectSnapshot] = React.useState(JSON.parse(JSON.stringify(project)))
 
   const handleChange = (event, newValue) => {
     setSelectedTab(newValue)
@@ -251,7 +251,7 @@ export function ProjectView({ initialProject }: ProjectProps) {
         {/* Hidden link for use by downloads */ }
         <a style={ { display: "none" } } href="#" id="download-link"/>
         <Button onClick={ () => {
-          setProjectSnapshot({ ...project })
+          setProjectSnapshot(JSON.parse(JSON.stringify(project)))
           setShowSettings(true) 
         } }>
           Settings
@@ -273,6 +273,7 @@ export function ProjectView({ initialProject }: ProjectProps) {
           // Create a new barebones project
           const newProject = makeNewProject()
           setProject(newProject)
+          setProjectSnapshot(JSON.parse(JSON.stringify(newProject)))
 
           // Select the default tab
           handleChange(null, defaultTab)

--- a/src/ui/ProjectView.tsx
+++ b/src/ui/ProjectView.tsx
@@ -161,6 +161,8 @@ export function ProjectView({ initialProject }: ProjectProps) {
                       allowCancel={ settingsDialogProps.allowCancel }
                       onCancel={ () => hideSettings() }
                       onSave={ (settings) => {
+                        // Remove leading and trailing whitespace on save
+                        settings.name = settings.name.trim()
                         const newProject = { ...project, settings }
                         regenerateFiles(newProject)
                         hideSettings()

--- a/src/ui/ProjectView.tsx
+++ b/src/ui/ProjectView.tsx
@@ -221,7 +221,6 @@ export function ProjectView({ initialProject }: ProjectProps) {
 
           // Select the default tab
           handleChange(null, defaultTab)
-          console.log('Opening settings')
           setSettingsDialogProps({ visible: true, allowCancel: false })
         } }>
           New

--- a/src/ui/ProjectView.tsx
+++ b/src/ui/ProjectView.tsx
@@ -26,7 +26,7 @@ const saveProject = (project: Project) => {
   console.log(savedProject)
 
   const link = document.getElementById("download-link")
-  const fileName = `${ project.settings.name }.json`
+  const fileName = `${ project.settings["robotbuilder.general.project_name"] }.json`
   const file = new Blob([savedProject], { type: "text/plain" })
   link.setAttribute("href", window.URL.createObjectURL(file))
   link.setAttribute("download", fileName)
@@ -113,7 +113,7 @@ const exportProject = async (project: Project) => {
   await Promise.all(project.generatedFiles.map(file => {
     return zipWriter.add(file.name, new TextReader(file.contents))
   }).concat([
-    zipWriter.add(`${ project.settings.name }.json`, new TextReader(savedProjectContents)),
+    zipWriter.add(`${ project.settings["robotbuilder.general.project_name"] }.json`, new TextReader(savedProjectContents)),
   ]))
 
 
@@ -123,7 +123,7 @@ const exportProject = async (project: Project) => {
   const link = document.createElement("a")
   const objurl = URL.createObjectURL(zipFile)
 
-  link.download = `${ project.settings.name }.zip`
+  link.download = `${ project.settings["robotbuilder.general.project_name"] }.zip`
   link.href = objurl
   link.click()
 }
@@ -162,7 +162,7 @@ export function ProjectView({ initialProject }: ProjectProps) {
                       onCancel={ () => hideSettings() }
                       onSave={ (settings) => {
                         // Remove leading and trailing whitespace on save
-                        settings.name = settings.name.trim()
+                        // settings.name = settings.name.trim()
                         const newProject = { ...project, settings }
                         regenerateFiles(newProject)
                         hideSettings()
@@ -173,10 +173,10 @@ export function ProjectView({ initialProject }: ProjectProps) {
           <span style={{ color: "white", fontWeight: "500", margin: "auto", marginLeft: "1rem", fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif', textTransform: "uppercase", letterSpacing: "0.02857em", lineHeight: "1.25", fontSize: "0.875rem" }}>
             {
               (() => {
-                if (/^[ ]*$/.test(project.settings.name) || !(project.settings.teamNumber > 0)) {
+                if (/^[ ]*$/.test(project.settings["robotbuilder.general.project_name"] as string) || !(project.settings["robotbuilder.general.team_number"] as number > 0)) {
                   return null
                 } else {
-                  return (<>Team { project.settings.teamNumber } - { project.settings.name }</>)
+                  return (<>Team { project.settings["robotbuilder.general.team_number"] } - { project.settings["robotbuilder.general.project_name"] }</>)
                 }
               })()
             }

--- a/src/ui/ProjectView.tsx
+++ b/src/ui/ProjectView.tsx
@@ -277,6 +277,7 @@ export function ProjectView({ initialProject }: ProjectProps) {
 
           // Select the default tab
           handleChange(null, defaultTab)
+          setShowSettings(true)
         } }>
           New
         </Button>

--- a/src/ui/project/SettingsDialog.tsx
+++ b/src/ui/project/SettingsDialog.tsx
@@ -38,7 +38,7 @@ export default function({ project, visible, allowCancel, onSave, onCancel  }: Se
             <TableRow>
               <TableCell>
                 <HelpableLabel description="The name of your robot project">
-                Project Name
+                  Project Name
                 </HelpableLabel>
               </TableCell>
               <TableCell>
@@ -52,7 +52,7 @@ export default function({ project, visible, allowCancel, onSave, onCancel  }: Se
             <TableRow>
               <TableCell>
                 <HelpableLabel description="Your FRC team number. You ought to know this!">
-                Team Number
+                  Team Number
                 </HelpableLabel>
               </TableCell>
               <TableCell>
@@ -81,7 +81,7 @@ export default function({ project, visible, allowCancel, onSave, onCancel  }: Se
             <TableRow>
               <TableCell>
                 <HelpableLabel description="Enables support for automatic data logging in your project via the Epilogue library">
-                Enable Epilogue Logging
+                  Enable Epilogue Logging
                 </HelpableLabel>
               </TableCell>
               <TableCell>

--- a/src/ui/project/SettingsDialog.tsx
+++ b/src/ui/project/SettingsDialog.tsx
@@ -30,7 +30,7 @@ export default function SettingsDialog({ project, visible, allowCancel, onSave, 
   return (
     <Dialog open={ visible } className="project-settings-dialog">
       <DialogTitle style={{ textAlign: "center" }}>
-      Project Settings
+        Project Settings
       </DialogTitle>
       <DialogContent>
         <Table>
@@ -96,13 +96,13 @@ export default function SettingsDialog({ project, visible, allowCancel, onSave, 
         {
           allowCancel ? (
             <Button onClick={ () => onCancel(settings) }>
-            Cancel
+              Cancel
             </Button>
           )
             : <></>
         }
         <Button disabled={ !isValid } onClick={ () => onSave(settings) }>
-        Apply
+          Apply
         </Button>
       </DialogActions>
     </Dialog>

--- a/src/ui/project/SettingsDialog.tsx
+++ b/src/ui/project/SettingsDialog.tsx
@@ -1,7 +1,7 @@
 import { DialogTitle, DialogContent, Table, TableBody, TableRow, TableCell, Input, Switch, DialogActions, Button } from "@mui/material"
 import Dialog from "@mui/material/Dialog"
 import React, { useEffect, useState } from "react"
-import { Project, Settings, regenerateFiles } from "../../bindings/Project"
+import { Project, Settings } from "../../bindings/Project"
 import { HelpableLabel } from "../HelpableLabel"
 
 type SettingsDialogProps = {
@@ -12,7 +12,7 @@ type SettingsDialogProps = {
   onCancel: (projectSettings: Settings) => void
 }
 
-export default function({ project, visible, allowCancel, onSave, onCancel  }: SettingsDialogProps) {
+export default function SettingsDialog({ project, visible, allowCancel, onSave, onCancel  }: SettingsDialogProps) {
   const blankStringRegex = /^[ ]*$/
 
   const [settings, setSettings] = useState({ ...project.settings })

--- a/src/ui/project/SettingsDialog.tsx
+++ b/src/ui/project/SettingsDialog.tsx
@@ -19,94 +19,92 @@ export default function({ project, visible, allowCancel, onSave, onCancel  }: Se
   const [isValid, setValid] = useState(false)
 
   useEffect(() => {
-    console.log('Refreshing settings state to', project.settings)
     setSettings({ ...project.settings })
   }, [project, visible])
 
   useEffect(() => {
     const isValid = !blankStringRegex.test(settings.name) && settings.teamNumber > 0
     setValid(isValid)
-    console.log('Checking validity of settings', settings, ' - ', isValid)
   }, [settings])
 
   return (
     <Dialog open={ visible } className="project-settings-dialog">
-    <DialogTitle style={{ textAlign: "center" }}>
+      <DialogTitle style={{ textAlign: "center" }}>
       Project Settings
-    </DialogTitle>
-    <DialogContent>
-      <Table>
-        <TableBody>
-          <TableRow>
-            <TableCell>
-              <HelpableLabel description="The name of your robot project">
+      </DialogTitle>
+      <DialogContent>
+        <Table>
+          <TableBody>
+            <TableRow>
+              <TableCell>
+                <HelpableLabel description="The name of your robot project">
                 Project Name
-              </HelpableLabel>
-            </TableCell>
-            <TableCell>
-              <Input type="text"
-                     placeholder={ "New Project" }
-                     value={ settings.name }
-                     error={ blankStringRegex.test(settings.name) }
-                     onChange={ (event) => setSettings({ ...settings, name: event.target.value}) } />
-            </TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell>
-              <HelpableLabel description="Your FRC team number. You ought to know this!">
+                </HelpableLabel>
+              </TableCell>
+              <TableCell>
+                <Input type="text"
+                       placeholder={ "New Project" }
+                       value={ settings.name }
+                       error={ blankStringRegex.test(settings.name) }
+                       onChange={ (event) => setSettings({ ...settings, name: event.target.value }) } />
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>
+                <HelpableLabel description="Your FRC team number. You ought to know this!">
                 Team Number
-              </HelpableLabel>
-            </TableCell>
-            <TableCell>
-              <Input type="text"
-                     placeholder="0000"
-                     value={ isNaN(settings.teamNumber) ? "" : settings.teamNumber?.toFixed(0) ?? "" }
-                     // Using not-greater-than-zero to account for null and NaN when the number field is blank
-                     error={ !(settings.teamNumber > 0) }
-                     onChange={ (event) => {
+                </HelpableLabel>
+              </TableCell>
+              <TableCell>
+                <Input type="text"
+                       placeholder="0000"
+                       value={ isNaN(settings.teamNumber) ? "" : settings.teamNumber?.toFixed(0) ?? "" }
+                       // Using not-greater-than-zero to account for null and NaN when the number field is blank
+                       error={ !(settings.teamNumber > 0) }
+                       onChange={ (event) => {
                        // Prevent non-numeric values from being entered
-                       const input = event.target.value
-                       if (!input.match(/^([1-9]+[0-9]*)?$/g)) {
-                         event.target.value = input.replaceAll(/[^0-9]+/g, "")
+                         const input = event.target.value
+                         if (!input.match(/^([1-9]+[0-9]*)?$/g)) {
+                           event.target.value = input.replaceAll(/[^0-9]+/g, "")
 
-                         // Prevent leading zeroes
-                         if (event.target.value.charAt(0) === '0') {
-                           event.target.value = event.target.value.substring(1)
+                           // Prevent leading zeroes
+                           if (event.target.value.charAt(0) === "0") {
+                             event.target.value = event.target.value.substring(1)
+                           }
+                           return
                          }
-                         return
-                       }
 
-                       setSettings({ ...settings, teamNumber: parseInt(event.target.value) })
-                     } }/>
-            </TableCell>
-          </TableRow>
-          <TableRow>
-            <TableCell>
-              <HelpableLabel description="Enables support for automatic data logging in your project via the Epilogue library">
+                         setSettings({ ...settings, teamNumber: parseInt(event.target.value) })
+                       } }/>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>
+                <HelpableLabel description="Enables support for automatic data logging in your project via the Epilogue library">
                 Enable Epilogue Logging
-              </HelpableLabel>
-            </TableCell>
-            <TableCell>
-              <Switch checked={ settings.epilogueSupport }
-                      onChange={ (event) => setSettings({ ...settings, epilogueSupport: event.target.checked}) } />
-            </TableCell>
-          </TableRow>
-        </TableBody>
-      </Table>
-    </DialogContent>
-    <DialogActions>
-      {
-        allowCancel ? (
-          <Button onClick={ () => onCancel(settings) }>
+                </HelpableLabel>
+              </TableCell>
+              <TableCell>
+                <Switch checked={ settings.epilogueSupport }
+                        onChange={ (event) => setSettings({ ...settings, epilogueSupport: event.target.checked }) } />
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </DialogContent>
+      <DialogActions>
+        {
+          allowCancel ? (
+            <Button onClick={ () => onCancel(settings) }>
             Cancel
-          </Button>
+            </Button>
           )
-          : <></>
-      }
-      <Button disabled={ !isValid } onClick={ () => onSave(settings) }>
+            : <></>
+        }
+        <Button disabled={ !isValid } onClick={ () => onSave(settings) }>
         Apply
-      </Button>
-    </DialogActions>
-  </Dialog>
+        </Button>
+      </DialogActions>
+    </Dialog>
   )
 }

--- a/src/ui/project/SettingsDialog.tsx
+++ b/src/ui/project/SettingsDialog.tsx
@@ -1,0 +1,112 @@
+import { DialogTitle, DialogContent, Table, TableBody, TableRow, TableCell, Input, Switch, DialogActions, Button } from "@mui/material"
+import Dialog from "@mui/material/Dialog"
+import React, { useEffect, useState } from "react"
+import { Project, Settings, regenerateFiles } from "../../bindings/Project"
+import { HelpableLabel } from "../HelpableLabel"
+
+type SettingsDialogProps = {
+  project: Project
+  visible: boolean
+  allowCancel: boolean
+  onSave: (projectSettings: Settings) => void
+  onCancel: (projectSettings: Settings) => void
+}
+
+export default function({ project, visible, allowCancel, onSave, onCancel  }: SettingsDialogProps) {
+  const blankStringRegex = /^[ ]*$/g
+
+  const [settings, setSettings] = useState({ ...project.settings })
+  const [isValid, setValid] = useState(false)
+
+  useEffect(() => {
+    console.log('Refreshing settings state to', project.settings)
+    setSettings({ ...project.settings })
+  }, [project, visible])
+
+  useEffect(() => {
+    const isValid = !blankStringRegex.test(settings.name) && settings.teamNumber > 0
+    setValid(isValid)
+    console.log('Checking validity of settings', settings, ' - ', isValid)
+  }, [settings])
+
+  return (
+    <Dialog open={ visible } className="project-settings-dialog">
+    <DialogTitle style={{ textAlign: "center" }}>
+      Project Settings
+    </DialogTitle>
+    <DialogContent>
+      <Table>
+        <TableBody>
+          <TableRow>
+            <TableCell>
+              <HelpableLabel description="The name of your robot project">
+                Project Name
+              </HelpableLabel>
+            </TableCell>
+            <TableCell>
+              <Input type="text"
+                     placeholder={ "New Project" }
+                     value={ settings.name }
+                     error={ blankStringRegex.test(settings.name) }
+                     onChange={ (event) => setSettings({ ...settings, name: event.target.value}) } />
+            </TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>
+              <HelpableLabel description="Your FRC team number. You ought to know this!">
+                Team Number
+              </HelpableLabel>
+            </TableCell>
+            <TableCell>
+              <Input type="text"
+                     placeholder="0000"
+                     value={ isNaN(settings.teamNumber) ? "" : settings.teamNumber?.toFixed(0) ?? "" }
+                     // Using not-greater-than-zero to account for null and NaN when the number field is blank
+                     error={ !(settings.teamNumber > 0) }
+                     onChange={ (event) => {
+                       // Prevent non-numeric values from being entered
+                       const input = event.target.value
+                       if (!input.match(/^([1-9]+[0-9]*)?$/g)) {
+                         event.target.value = input.replaceAll(/[^0-9]+/g, "")
+
+                         // Prevent leading zeroes
+                         if (event.target.value.charAt(0) === '0') {
+                           event.target.value = event.target.value.substring(1)
+                         }
+                         return
+                       }
+
+                       setSettings({ ...settings, teamNumber: parseInt(event.target.value) })
+                     } }/>
+            </TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>
+              <HelpableLabel description="Enables support for automatic data logging in your project via the Epilogue library">
+                Enable Epilogue Logging
+              </HelpableLabel>
+            </TableCell>
+            <TableCell>
+              <Switch checked={ settings.epilogueSupport }
+                      onChange={ (event) => setSettings({ ...settings, epilogueSupport: event.target.checked}) } />
+            </TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </DialogContent>
+    <DialogActions>
+      {
+        allowCancel ? (
+          <Button onClick={ () => onCancel(settings) }>
+            Cancel
+          </Button>
+          )
+          : <></>
+      }
+      <Button disabled={ !isValid } onClick={ () => onSave(settings) }>
+        Apply
+      </Button>
+    </DialogActions>
+  </Dialog>
+  )
+}

--- a/src/ui/project/SettingsDialog.tsx
+++ b/src/ui/project/SettingsDialog.tsx
@@ -13,7 +13,7 @@ type SettingsDialogProps = {
 }
 
 export default function({ project, visible, allowCancel, onSave, onCancel  }: SettingsDialogProps) {
-  const blankStringRegex = /^[ ]*$/g
+  const blankStringRegex = /^[ ]*$/
 
   const [settings, setSettings] = useState({ ...project.settings })
   const [isValid, setValid] = useState(false)

--- a/src/ui/robot/Robot.tsx
+++ b/src/ui/robot/Robot.tsx
@@ -67,11 +67,14 @@ export function Robot({ project }: { project: Project }) {
   // Reload the current file when the project changes
   useEffect(() => {
     const currentFile = selectedFile
-    setSelectedFile(project.generatedFiles.find(f => f.name === "README.md"))
+    const correspondingFile = project.generatedFiles.find(f => f.name === currentFile.name)
 
-    if (project.generatedFiles.find(f => f.name === currentFile.name)) {
-      // Show the original file if it still exists
-      setSelectedFile({ ...currentFile })
+    if (correspondingFile !== undefined) {
+      // The project changed but still has a file in the same path. Keep it rendered.
+      setSelectedFile(correspondingFile)
+    } else {
+      // Fall back to render the README. This should still exist, right?
+      setSelectedFile(project.generatedFiles.find(f => f.name === "README.md"))
     }
   }, [project])
 

--- a/src/ui/robot/Robot.tsx
+++ b/src/ui/robot/Robot.tsx
@@ -1,4 +1,4 @@
-import React, { CSSProperties, useState } from "react"
+import React, { CSSProperties, useEffect, useState } from "react"
 import { GeneratedFile, Project } from "../../bindings/Project"
 import { Box } from "@mui/material"
 import SyntaxHighlighter from "react-syntax-highlighter"
@@ -64,6 +64,17 @@ const sortTree = (roots: FileTreeEntry[], sorter: (a: FileTreeEntry, b: FileTree
 export function Robot({ project }: { project: Project }) {
   const [selectedFile, setSelectedFile] = useState(project.generatedFiles.find(f => f.name === ROBOT_CLASS_PATH))
 
+  // Reload the current file when the project changes
+  useEffect(() => {
+    const currentFile = selectedFile
+    setSelectedFile(project.generatedFiles.find(f => f.name === "README.md"))
+
+    if (project.generatedFiles.find(f => f.name === currentFile.name)) {
+      // Show the original file if it still exists
+      setSelectedFile({ ...currentFile })
+    }
+  }, [project])
+
   return (
     <PanelGroup direction="horizontal" style={{ height: "100%" }}>
       <Panel defaultSize={ 30 } minSize={ 20 }>
@@ -85,7 +96,9 @@ export function Robot({ project }: { project: Project }) {
       <PanelResizeHandle className="code-panel-divider" />
       <Panel defaultSize={ 70 } minSize={ 50 } style={{ height: "calc(100% - 50px)", overflowY: "clip" }}>
         <Box style={{ height: "100%" }}>
-          <code style={{ padding: "0.5em", paddingLeft: "3em", fontSize: "10pt", color: "gray" }}>/{ selectedFile.name }</code>
+          <code style={{ padding: "0.5em", paddingLeft: "3em", fontSize: "10pt", color: "gray" }}>
+            /{ selectedFile.name }
+          </code>
           <div style={{ height: "100%", overflowY: "scroll" }}>
             <SyntaxHighlighter
               language={ selectedFile.name.split(".").slice(-1)[0] }

--- a/src/ui/subsystem/Subsystem.tsx
+++ b/src/ui/subsystem/Subsystem.tsx
@@ -238,7 +238,8 @@ function SubsystemPane({ subsystem, project }: BasicOpts) {
                             setEditedAction(null)
                           } }/>
 
-      <CreateStateDialog open={ showCreateStateDialog }
+      <CreateStateDialog project={ project }
+                         open={ showCreateStateDialog }
                          subsystem={ subsystem }
                          editedState={ editedState }
                          onCancel={ closeStateDialog }
@@ -954,6 +955,7 @@ type StateParams = {
 };
 
 type CreateStateDialogProps = {
+  project: Project;
   open: boolean;
   subsystem: Subsystem;
   editedState: SubsystemState | null;
@@ -963,6 +965,7 @@ type CreateStateDialogProps = {
 };
 
 function CreateStateDialog({
+  project,
   open,
   subsystem,
   editedState,
@@ -1021,7 +1024,7 @@ function CreateStateDialog({
               methodName: stateMethod,
               params: stateParams,
             })
-            return generateState(dummyState, subsystem)
+            return generateState(project, dummyState, subsystem)
           })() }
         </SyntaxHighlighter>
       </DialogContent>


### PR DESCRIPTION
Add settings for team number and epilogue support (on/off)

Dynamically regenerate code when project settings change

Add a settings dialog for configuration; project name editing has been moved to this dialog. Team number and project name are now displayed read-only in the top left where the project name input used to be. The dialog is displayed by default when the app is loaded

Settings are validated and cannot be applied if invalid - team numbers must be positive integers, and project names must have at least one non-whitespace character. The "Apply" button is disabled if validation checks fail

Invalid inputs:
<img width="1792" alt="Screenshot 2024-09-28 at 1 45 58 PM" src="https://github.com/user-attachments/assets/44f39742-f601-45da-aaab-14897c6d9c1b">

Valid inputs:
<img width="1792" alt="Screenshot 2024-09-28 at 1 46 14 PM" src="https://github.com/user-attachments/assets/070daf43-253f-41b2-90f7-3c4719536a9a">

