### PR TITLE
Exclude build artifacts from eslint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,9 @@ import pluginReact from "eslint-plugin-react"
 
 export default [
   {
+    ignores: ["build/**"],
+  },
+  {
     files: ["**/*.{js,mjs,cjs,ts,jsx,tsx}"],
     plugins: {
       pluginReact,


### PR DESCRIPTION
Prevents it attempting to lint irrelevant files that will likely fail eslint rules